### PR TITLE
feat: Set default value of callback_url to null if not present for prepareFiles call

### DIFF
--- a/src/Api/EidEasyApi.php
+++ b/src/Api/EidEasyApi.php
@@ -177,7 +177,7 @@ class EidEasyApi
             'nodownload'            => $parameters['nodownload'] ?? false,
             'noemails'              => $parameters['noemails'] ?? false,
             'hide_preview_download' => $parameters['hide_preview_download'] ?? false,
-            'callback_url'          => $parameters['callback_url'] ?? false,
+            'callback_url'          => $parameters['callback_url'] ?? null,
         ];
 
         $data = $this->addPrepareFileSigningParams($data, $parameters);


### PR DESCRIPTION
Fixes https://github.com/eideasy/eideasy-php/issues/13